### PR TITLE
Fixes for compiling with MSVC 2013.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@
 #
 ###############################################################################
 
+if(CMAKE_PROJECT_NAME STREQUAL maidsafe)
+  include("MaidSafe CMakeLists.txt")
+  return()
+endif()
+
 cmake_minimum_required(VERSION 2.8)
 project(crux CXX)
 

--- a/MaidSafe CMakeLists.txt
+++ b/MaidSafe CMakeLists.txt
@@ -1,0 +1,97 @@
+#==================================================================================================#
+#                                                                                                  #
+#  Copyright 2015 MaidSafe.net limited                                                             #
+#                                                                                                  #
+#  Distributed under the Boost Software License, Version 1.0.                                      #
+#  (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)         #
+#                                                                                                  #
+#==================================================================================================#
+
+
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake_modules/standard_setup.cmake")
+  cmake_minimum_required(VERSION 2.8)  # To suppress warning cluttering error message
+  set(Msg "\nThis project can currently only be build as part of the MaidSafe super-project.  For")
+  set(Msg "${Msg} full details, see https://github.com/maidsafe/MaidSafe/wiki/Build-Instructions\n")
+  message(FATAL_ERROR "${Msg}")
+endif()
+
+project(crux)
+
+include(../../cmake_modules/standard_setup.cmake)
+
+
+#==================================================================================================#
+# Set up all files as GLOBs                                                                        #
+#==================================================================================================#
+# Can't use 'ms_glob_dir' since paths and file extensions don't follow MaidSafe conventions.
+file(GLOB CruxApi ${PROJECT_SOURCE_DIR}/include/maidsafe/crux/*.hpp)
+file(GLOB CruxHeaders ${PROJECT_SOURCE_DIR}/src/*.hpp)
+file(GLOB CruxSources ${PROJECT_SOURCE_DIR}/src/*.cpp)
+source_group("CRUX API Files" FILES ${CruxApi})
+source_group("CRUX Header Files" FILES ${CruxHeaders})
+source_group("CRUX Source Files" FILES ${CruxSources})
+
+file(GLOB CruxDetailApi ${PROJECT_SOURCE_DIR}/include/maidsafe/crux/detail/*.hpp)
+file(GLOB CruxDetailHeaders ${PROJECT_SOURCE_DIR}/src/detail/*.hpp)
+file(GLOB CruxDetailSources ${PROJECT_SOURCE_DIR}/src/detail/*.cpp)
+source_group("CRUX Detail API Files" FILES ${CruxDetailApi})
+source_group("CRUX Detail Header Files" FILES ${CruxDetailHeaders})
+source_group("CRUX Detail Source Files" FILES ${CruxDetailSources})
+set(CruxAllFiles ${CruxApi} ${CruxHeaders} ${CruxSources} ${CruxDetailApi} ${CruxDetailHeaders} ${CruxDetailSources})
+
+file(GLOB CruxTestsHeaders ${PROJECT_SOURCE_DIR}/test/*.hpp)
+file(GLOB CruxTestsSources ${PROJECT_SOURCE_DIR}/test/*.cpp)
+set(CruxTestsAllFiles ${CruxTestsHeaders} ${CruxTestsSources})
+source_group("Tests Headers Files" FILES ${CruxTestsHeaders})
+source_group("Tests Source Files" FILES ${CruxTestsSources})
+
+
+#==================================================================================================#
+# Define MaidSafe libraries and executables                                                        #
+#==================================================================================================#
+ms_add_static_library(maidsafe_crux ${CruxAllFiles})
+target_include_directories(maidsafe_crux PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(maidsafe_crux maidsafe_common)
+
+ms_add_executable(async_echo_server "Examples/CRUX" ${PROJECT_SOURCE_DIR}/example/async/echo_server.cpp)
+target_link_libraries(async_echo_server maidsafe_crux)
+
+ms_add_executable(async_echo_client "Examples/CRUX" ${PROJECT_SOURCE_DIR}/example/async/echo_client.cpp)
+target_link_libraries(async_echo_client maidsafe_crux)
+
+ms_add_executable(coroutine_echo_client "Examples/CRUX" ${PROJECT_SOURCE_DIR}/example/coroutine/echo_client.cpp)
+target_link_libraries(coroutine_echo_client maidsafe_crux)
+
+ms_add_executable(future_echo_client "Examples/CRUX" ${PROJECT_SOURCE_DIR}/example/future/echo_client.cpp)
+target_link_libraries(future_echo_client maidsafe_crux)
+
+
+if(INCLUDE_TESTS)
+  ms_add_executable(test_crux "Tests/CRUX" ${CruxTestsAllFiles})
+  target_link_libraries(test_crux maidsafe_crux ${BoostTestLibs})
+endif()
+
+ms_rename_outdated_built_exes()
+
+
+#==================================================================================================#
+# Set compiler and linker flags                                                                    #
+#==================================================================================================#
+include(standard_flags)
+
+
+#==================================================================================================#
+# Tests                                                                                            #
+#==================================================================================================#
+if(INCLUDE_TESTS)
+  ms_add_default_tests()
+  add_test(NAME AllCruxTests COMMAND $<TARGET_FILE:test_crux>)
+  set_property(TEST AllCruxTests PROPERTY LABELS Crux ${TASK_LABEL})
+  set(AllCruxTestsTimeout 60)  # seconds
+  ms_update_test_timeout(AllCruxTestsTimeout)
+  set_property(TEST AllCruxTests PROPERTY TIMEOUT ${AllCruxTestsTimeout})
+  ms_test_summary_output()
+endif()

--- a/example/async/echo_client.cpp
+++ b/example/async/echo_client.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <iostream>
 #include <boost/asio/connect.hpp>
 #include <maidsafe/crux/socket.hpp>
 
@@ -49,7 +50,7 @@ private:
         std::shared_ptr<message_type> message = std::make_shared<message_type>(data.begin(), data.end());
         socket.async_send(boost::asio::buffer(*message),
                           [this, message] (boost::system::error_code error,
-                                           std::size_t length)
+                                           std::size_t /*length*/)
                           {
                               if (!error)
                               {
@@ -66,8 +67,8 @@ private:
     {
         std::shared_ptr<message_type> message = std::make_shared<message_type>(1400);
         socket.async_receive(boost::asio::buffer(*message),
-                             [this, message] (boost::system::error_code error,
-                                              std::size_t length)
+                             [this, message] (boost::system::error_code /*error*/,
+                                              std::size_t /*length*/)
                              {
                                  for (auto ch : *message)
                                  {

--- a/example/async/echo_server.cpp
+++ b/example/async/echo_server.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     if (argc <= 1)
         return 1;
 
-    auto server_port = std::stoi(argv[1]);
+    auto server_port = static_cast<unsigned short>(std::stoi(argv[1]));
 
     boost::asio::io_service io;
     boost::asio::ip::udp::endpoint endpoint(boost::asio::ip::udp::v4(), server_port);

--- a/example/coroutine/echo_client.cpp
+++ b/example/coroutine/echo_client.cpp
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <functional>
+#include <iostream>
 #include <boost/asio/spawn.hpp>
 #include <maidsafe/crux/socket.hpp>
 

--- a/example/future/echo_client.cpp
+++ b/example/future/echo_client.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <functional>
 #include <thread>
+#include <iostream>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/use_future.hpp>
 #include <maidsafe/crux/socket.hpp>

--- a/include/maidsafe/crux/detail/header.hpp
+++ b/include/maidsafe/crux/detail/header.hpp
@@ -55,10 +55,10 @@ struct handshake {
     }
 
     void encode(detail::encoder& encoder) const {
-        encoder.put<std::uint16_t>(header::constant::type_handshake
-                                   | std::min<std::size_t>(3, retransmission_count)
-                                   | (ack ? header::constant::ack_type_cumulative
-                                          : header::constant::ack_type_none));
+        encoder.put<std::uint16_t>(
+            header::constant::type_handshake
+            | static_cast<std::uint16_t>(std::min<std::size_t>(3, retransmission_count))
+            | (ack ? header::constant::ack_type_cumulative : header::constant::ack_type_none));
         encoder.put<std::uint16_t>(version);
         encoder.put<std::uint32_t>(initial_sequence_number.value());
         encoder.put<std::uint32_t>(ack ? ack->value() : 0);
@@ -93,10 +93,10 @@ struct keepalive {
     }
 
     void encode(detail::encoder& encoder) const {
-        encoder.put<std::uint16_t>(header::constant::type_keepalive
-                                   | std::min<std::size_t>(3, retransmission_count)
-                                   | (ack ? header::constant::ack_type_cumulative
-                                          : header::constant::ack_type_none));
+        encoder.put<std::uint16_t>(
+            header::constant::type_keepalive
+            | static_cast<std::uint16_t>(std::min<std::size_t>(3, retransmission_count))
+            | (ack ? header::constant::ack_type_cumulative : header::constant::ack_type_none));
         encoder.put<std::uint16_t>(0);
         encoder.put<std::uint32_t>(sequence_number.value());
         encoder.put<std::uint32_t>(ack ? ack->value() : 0);
@@ -132,10 +132,10 @@ struct data {
     }
 
     void encode(detail::encoder& encoder) const {
-        encoder.put<std::uint16_t>(header::constant::type_data
-                                   | std::min<std::size_t>(3, retransmission_count)
-                                   | (ack ? header::constant::ack_type_cumulative
-                                          : header::constant::ack_type_none));
+        encoder.put<std::uint16_t>(
+            header::constant::type_data
+            | static_cast<std::uint16_t>(std::min<std::size_t>(3, retransmission_count))
+            | (ack ? header::constant::ack_type_cumulative : header::constant::ack_type_none));
         encoder.put<std::uint16_t>(0);
         encoder.put<std::uint32_t>(sequence_number.value());
         encoder.put<std::uint32_t>(ack ? ack->value() : 0);

--- a/include/maidsafe/crux/detail/multiplexer.hpp
+++ b/include/maidsafe/crux/detail/multiplexer.hpp
@@ -70,7 +70,7 @@ public:
                    const endpoint_type& endpoint,
                    sequence_type sequence,
                    boost::optional<ack_sequence_type> ack,
-                   std::size_t retransmission_count,
+                   std::uint16_t retransmission_count,
                    WriteHandler&& handler);
 
     template <typename ConnectHandler>
@@ -272,7 +272,7 @@ void multiplexer::send_data(ConstBufferSequence&& buffers,
                             const endpoint_type& endpoint,
                             sequence_type sequence,
                             boost::optional<ack_sequence_type> ack,
-                            std::size_t retransmission_count,
+                            std::uint16_t retransmission_count,
                             WriteHandler&& handler)
 {
     auto header = std::make_shared<header::data_type>();

--- a/include/maidsafe/crux/detail/sequence_number.hpp
+++ b/include/maidsafe/crux/detail/sequence_number.hpp
@@ -12,11 +12,13 @@
 #define MAIDSAFE_CRUX_DETAIL_SEQUENCE_NUMBER_HPP
 
 #include <type_traits>
+#include <boost/config.hpp>
+#include <boost/integer_traits.hpp>
 
 namespace maidsafe { namespace crux { namespace detail {
 
 template< typename NumericType
-        , NumericType Max = std::numeric_limits<NumericType>::max()
+        , NumericType Max = boost::integer_traits<NumericType>::const_max
         >
 class sequence_number {
 
@@ -27,8 +29,8 @@ class sequence_number {
 public:
     using value_type = NumericType;
     using difference_type = typename std::make_signed<value_type>::type;
-    static constexpr value_type max_value = Max;
-    static constexpr value_type middle_value = Max/2U;
+    BOOST_STATIC_CONSTEXPR value_type max_value = Max;
+    BOOST_STATIC_CONSTEXPR value_type middle_value = Max/2U;
 
 public:
     sequence_number();
@@ -155,7 +157,7 @@ sequence_number<NumericType, Max>::distance(const sequence_number& other) const
         if (diff > middle_value)
         {
             const value_type v = max_value - diff + 1;
-            return -v;
+            return -static_cast<difference_type>(v);
         }
         else
         {
@@ -168,11 +170,11 @@ sequence_number<NumericType, Max>::distance(const sequence_number& other) const
         if (diff > middle_value)
         {
             const value_type v = max_value - diff + 1;
-            return (v > middle_value) ? -v : v;
+            return (v > middle_value) ? -static_cast<difference_type>(v) : v;
         }
         else
         {
-            return -diff;
+            return -static_cast<difference_type>(diff);
         }
     }
 }

--- a/include/maidsafe/crux/detail/transmit_queue.hpp
+++ b/include/maidsafe/crux/detail/transmit_queue.hpp
@@ -176,8 +176,8 @@ void transmit_queue<Index>::start_step(typename entries_type::iterator entry_i) 
                    }
                    // FIXME: Period should be = 
                    //        max(0, entry->period - duration of this step)
-                   timer.set_period(entry->period);
-                   timer.start();
+                   this->timer.set_period(entry->period);
+                   this->timer.start();
                });
 }
 

--- a/include/maidsafe/crux/socket.hpp
+++ b/include/maidsafe/crux/socket.hpp
@@ -783,7 +783,7 @@ void socket::process_handshake(sequence_type initial,
                      if (connect_handler)
                      {
                          connect_handler(error);
-                         connect_handler = 0;
+                         connect_handler = nullptr;
                      }
                  }
              });
@@ -801,7 +801,7 @@ void socket::process_handshake(sequence_type initial,
                  if (connect_handler)
                  {
                      connect_handler(error);
-                     connect_handler = 0;
+                     connect_handler = nullptr;
                  }
              });
         break;

--- a/test/cumulative_set_suite.cpp
+++ b/test/cumulative_set_suite.cpp
@@ -20,9 +20,12 @@ using cumulative_set = maidsafe::crux::detail::cumulative_set<sequence_number, s
 namespace std
 {
 
-ostream& operator << (ostream& stream, const sequence_number& number)
+ostream& operator << (ostream& stream, const boost::optional<sequence_number>& number)
 {
-    stream << number.value();
+    if (number)
+        stream << number.value();
+    else
+        stream << "no value";
     return stream;
 }
 

--- a/test/sequence_number.cpp
+++ b/test/sequence_number.cpp
@@ -9,6 +9,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/test/unit_test.hpp>
+#include <boost/config.hpp>
+#include <boost/integer_traits.hpp>
 #include <cstdint>
 #include <maidsafe/crux/detail/sequence_number.hpp>
 
@@ -16,8 +18,8 @@ using maidsafe::crux::detail::sequence_number;
 
 template<class SN> void test_limits()
 {
-    constexpr auto max = SN::max_value;
-    constexpr auto half = max/2;
+    BOOST_STATIC_CONSTEXPR auto max = SN::max_value;
+    BOOST_STATIC_CONSTEXPR auto half = max/2;
 
     BOOST_REQUIRE(SN(0)       < SN(1));
     BOOST_REQUIRE(SN(0)       < SN(half-1));
@@ -56,7 +58,7 @@ BOOST_AUTO_TEST_CASE(sequence_number_uint32)
 BOOST_AUTO_TEST_CASE(sequence_number_uint32_custom_max)
 {
     using T = std::uint32_t;
-    constexpr T max = std::numeric_limits<T>::max();
+    BOOST_STATIC_CONSTEXPR T max = boost::integer_traits<T>::const_max;
 
     test_limits<sequence_number<T, max/2>>();
     test_limits<sequence_number<T, max/4>>();
@@ -67,7 +69,7 @@ BOOST_AUTO_TEST_CASE(sequence_number_uint32_custom_max)
 BOOST_AUTO_TEST_CASE(sequence_number_pre_increment)
 {
     using T = std::uint8_t;
-    constexpr T max = std::numeric_limits<T>::max()/2;
+    BOOST_STATIC_CONSTEXPR T max = boost::integer_traits<T>::const_max/2;
     sequence_number<T, max> s;
     std::uint32_t counter = 0;
     while ((++s).value()) { ++counter; }
@@ -77,7 +79,7 @@ BOOST_AUTO_TEST_CASE(sequence_number_pre_increment)
 BOOST_AUTO_TEST_CASE(sequence_number_post_increment)
 {
     using T = std::uint8_t;
-    constexpr T max = std::numeric_limits<T>::max()/2;
+    BOOST_STATIC_CONSTEXPR T max = boost::integer_traits<T>::const_max/2;
     sequence_number<T, max> s;
     s++;
     std::uint32_t counter = 0;
@@ -88,7 +90,7 @@ BOOST_AUTO_TEST_CASE(sequence_number_post_increment)
 BOOST_AUTO_TEST_CASE(short_distances)
 {
     using T = std::uint16_t;
-    constexpr T max = sequence_number<T>::max_value;
+    BOOST_STATIC_CONSTEXPR T max = sequence_number<T>::max_value;
     sequence_number<T> zero(0);
     sequence_number<T> one(1);
     sequence_number<T> half(max/2);
@@ -118,7 +120,8 @@ BOOST_AUTO_TEST_CASE(short_distances)
 BOOST_AUTO_TEST_CASE(medium_distances)
 {
     using T = std::uint32_t;
-    constexpr T max = sequence_number<T>::max_value;
+    using difference_type = sequence_number<T>::difference_type;
+    BOOST_STATIC_CONSTEXPR T max = sequence_number<T>::max_value;
     sequence_number<T> zero(0);
     sequence_number<T> one(1);
     sequence_number<T> half(max/2);
@@ -131,14 +134,14 @@ BOOST_AUTO_TEST_CASE(medium_distances)
     BOOST_CHECK_EQUAL(largest.distance(second_largest), -1);
     BOOST_CHECK_EQUAL(largest.distance(zero), 1);
     BOOST_CHECK_EQUAL(zero.distance(largest), -1);
-    BOOST_CHECK_EQUAL(zero.distance(half), half.value());
-    BOOST_CHECK_EQUAL(half.distance(zero), -half.value());
-    BOOST_CHECK_EQUAL(one.distance(half), half.value() - 1);
-    BOOST_CHECK_EQUAL(half.distance(one), -(half.value() - 1));
-    BOOST_CHECK_EQUAL(largest.distance(half), -(half.value() + 1));
+    BOOST_CHECK_EQUAL(zero.distance(half), static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(zero), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(one.distance(half), static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(half.distance(one), -static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(largest.distance(half), -static_cast<difference_type>(half.value() + 1));
     BOOST_CHECK_EQUAL(half.distance(largest), largest.distance(half));
-    BOOST_CHECK_EQUAL(second_largest.distance(half), -half.value());
-    BOOST_CHECK_EQUAL(half.distance(second_largest), half.value());
+    BOOST_CHECK_EQUAL(second_largest.distance(half), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(second_largest), static_cast<difference_type>(half.value()));
     BOOST_CHECK_EQUAL(largest.distance(one), 2);
     BOOST_CHECK_EQUAL(one.distance(largest), -2);
     BOOST_CHECK_EQUAL(second_largest.distance(one), 3);
@@ -148,7 +151,8 @@ BOOST_AUTO_TEST_CASE(medium_distances)
 BOOST_AUTO_TEST_CASE(long_distances)
 {
     using T = std::uint64_t;
-    constexpr T max = sequence_number<T>::max_value;
+    using difference_type = sequence_number<T>::difference_type;
+    BOOST_STATIC_CONSTEXPR T max = sequence_number<T>::max_value;
     sequence_number<T> zero(0);
     sequence_number<T> one(1);
     sequence_number<T> half(max/2);
@@ -161,14 +165,14 @@ BOOST_AUTO_TEST_CASE(long_distances)
     BOOST_CHECK_EQUAL(largest.distance(second_largest), -1);
     BOOST_CHECK_EQUAL(largest.distance(zero), 1);
     BOOST_CHECK_EQUAL(zero.distance(largest), -1);
-    BOOST_CHECK_EQUAL(zero.distance(half), half.value());
-    BOOST_CHECK_EQUAL(half.distance(zero), -half.value());
-    BOOST_CHECK_EQUAL(one.distance(half), half.value() - 1);
-    BOOST_CHECK_EQUAL(half.distance(one), -(half.value() - 1));
-    BOOST_CHECK_EQUAL(largest.distance(half), -(half.value() + 1));
+    BOOST_CHECK_EQUAL(zero.distance(half), static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(zero), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(one.distance(half), static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(half.distance(one), -static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(largest.distance(half), -static_cast<difference_type>(half.value() + 1));
     BOOST_CHECK_EQUAL(half.distance(largest), largest.distance(half));
-    BOOST_CHECK_EQUAL(second_largest.distance(half), -half.value());
-    BOOST_CHECK_EQUAL(half.distance(second_largest), half.value());
+    BOOST_CHECK_EQUAL(second_largest.distance(half), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(second_largest), static_cast<difference_type>(half.value()));
     BOOST_CHECK_EQUAL(largest.distance(one), 2);
     BOOST_CHECK_EQUAL(one.distance(largest), -2);
     BOOST_CHECK_EQUAL(second_largest.distance(one), 3);
@@ -178,7 +182,7 @@ BOOST_AUTO_TEST_CASE(long_distances)
 BOOST_AUTO_TEST_CASE(custom_short_distances)
 {
     using T = std::uint16_t;
-    constexpr T max = std::numeric_limits<T>::max() / (1 << 1);
+    BOOST_STATIC_CONSTEXPR T max = boost::integer_traits<T>::const_max / (1 << 1);
     sequence_number<T, max> zero(0);
     sequence_number<T, max> one(1);
     sequence_number<T, max> half(max/2);
@@ -208,7 +212,8 @@ BOOST_AUTO_TEST_CASE(custom_short_distances)
 BOOST_AUTO_TEST_CASE(custom_medium_distances)
 {
     using T = std::uint32_t;
-    constexpr T max = std::numeric_limits<T>::max() / (1 << 1);
+    using difference_type = sequence_number<T>::difference_type;
+    BOOST_STATIC_CONSTEXPR T max = boost::integer_traits<T>::const_max / (1 << 1);
     sequence_number<T, max> zero(0);
     sequence_number<T, max> one(1);
     sequence_number<T, max> half(max/2);
@@ -221,14 +226,14 @@ BOOST_AUTO_TEST_CASE(custom_medium_distances)
     BOOST_CHECK_EQUAL(largest.distance(second_largest), -1);
     BOOST_CHECK_EQUAL(largest.distance(zero), 1);
     BOOST_CHECK_EQUAL(zero.distance(largest), -1);
-    BOOST_CHECK_EQUAL(zero.distance(half), half.value());
-    BOOST_CHECK_EQUAL(half.distance(zero), -half.value());
-    BOOST_CHECK_EQUAL(one.distance(half), half.value() - 1);
-    BOOST_CHECK_EQUAL(half.distance(one), -(half.value() - 1));
-    BOOST_CHECK_EQUAL(largest.distance(half), -(half.value() + 1));
+    BOOST_CHECK_EQUAL(zero.distance(half), static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(zero), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(one.distance(half), static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(half.distance(one), -static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(largest.distance(half), -static_cast<difference_type>(half.value() + 1));
     BOOST_CHECK_EQUAL(half.distance(largest), largest.distance(half));
-    BOOST_CHECK_EQUAL(second_largest.distance(half), -half.value());
-    BOOST_CHECK_EQUAL(half.distance(second_largest), half.value());
+    BOOST_CHECK_EQUAL(second_largest.distance(half), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(second_largest), static_cast<difference_type>(half.value()));
     BOOST_CHECK_EQUAL(largest.distance(one), 2);
     BOOST_CHECK_EQUAL(one.distance(largest), -2);
     BOOST_CHECK_EQUAL(second_largest.distance(one), 3);
@@ -238,7 +243,8 @@ BOOST_AUTO_TEST_CASE(custom_medium_distances)
 BOOST_AUTO_TEST_CASE(custom_long_distances)
 {
     using T = std::uint64_t;
-    constexpr T max = std::numeric_limits<T>::max() / (1 << 1);
+    using difference_type = sequence_number<T>::difference_type;
+    BOOST_STATIC_CONSTEXPR T max = boost::integer_traits<T>::const_max / (1 << 1);
     sequence_number<T, max> zero(0);
     sequence_number<T, max> one(1);
     sequence_number<T, max> half(max/2);
@@ -251,14 +257,14 @@ BOOST_AUTO_TEST_CASE(custom_long_distances)
     BOOST_CHECK_EQUAL(largest.distance(second_largest), -1);
     BOOST_CHECK_EQUAL(largest.distance(zero), 1);
     BOOST_CHECK_EQUAL(zero.distance(largest), -1);
-    BOOST_CHECK_EQUAL(zero.distance(half), half.value());
-    BOOST_CHECK_EQUAL(half.distance(zero), -half.value());
-    BOOST_CHECK_EQUAL(one.distance(half), half.value() - 1);
-    BOOST_CHECK_EQUAL(half.distance(one), -(half.value() - 1));
-    BOOST_CHECK_EQUAL(largest.distance(half), -(half.value() + 1));
+    BOOST_CHECK_EQUAL(zero.distance(half), static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(zero), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(one.distance(half), static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(half.distance(one), -static_cast<difference_type>(half.value() - 1));
+    BOOST_CHECK_EQUAL(largest.distance(half), -static_cast<difference_type>(half.value() + 1));
     BOOST_CHECK_EQUAL(half.distance(largest), largest.distance(half));
-    BOOST_CHECK_EQUAL(second_largest.distance(half), -half.value());
-    BOOST_CHECK_EQUAL(half.distance(second_largest), half.value());
+    BOOST_CHECK_EQUAL(second_largest.distance(half), -static_cast<difference_type>(half.value()));
+    BOOST_CHECK_EQUAL(half.distance(second_largest), static_cast<difference_type>(half.value()));
     BOOST_CHECK_EQUAL(largest.distance(one), 2);
     BOOST_CHECK_EQUAL(one.distance(largest), -2);
     BOOST_CHECK_EQUAL(second_largest.distance(one), 3);
@@ -268,7 +274,8 @@ BOOST_AUTO_TEST_CASE(custom_long_distances)
 BOOST_AUTO_TEST_CASE(custom4_short_distances)
 {
     using T = std::uint16_t;
-    constexpr T max = std::numeric_limits<T>::max() / (1 << 4);
+    using difference_type = sequence_number<T>::difference_type;
+    BOOST_STATIC_CONSTEXPR T max = boost::integer_traits<T>::const_max / (1 << 4);
     sequence_number<T, max> zero(0);
     sequence_number<T, max> one(1);
     sequence_number<T, max> half(max/2);

--- a/test/socket.cpp
+++ b/test/socket.cpp
@@ -39,13 +39,13 @@ BOOST_AUTO_TEST_CASE(accept___connect)
     bool tested_server = false;
 
     acceptor.async_accept(server_socket, [&](error_code error) {
-                                           BOOST_ASSERT(!error);
+                                           BOOST_VERIFY(!error);
                                            tested_server = true;
                                          });
 
     client_socket.async_connect(acceptor.local_endpoint(),
                                 [&](error_code error) {
-                                  BOOST_ASSERT(!error);
+                                  BOOST_VERIFY(!error);
                                   tested_client = true;
                                 });
 
@@ -74,12 +74,12 @@ BOOST_AUTO_TEST_CASE(accept_receive___connect_send)
     bool tested_send    = false;
 
     acceptor.async_accept(server_socket, [&](error_code error) {
-            BOOST_ASSERT(!error);
+            BOOST_VERIFY(!error);
 
             server_socket.async_receive(
                 asio::buffer(rx_data),
                 [&](const error_code& error, size_t size) {
-                  BOOST_ASSERT(!error);
+                  BOOST_VERIFY(!error);
                   BOOST_REQUIRE_EQUAL(size, tx_data.size());
                   BOOST_REQUIRE_EQUAL(to_string(rx_data), to_string(tx_data));
 
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(accept_receive___connect_send)
     client_socket.async_connect(
             acceptor.local_endpoint(),
             [&](error_code error) {
-              BOOST_ASSERT(!error);
+              BOOST_VERIFY(!error);
 
               client_socket.async_send(asio::buffer(tx_data),
                   [&](error_code error, size_t size) {
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(accept_send___connect_receive)
     bool tested_send    = false;
 
     acceptor.async_accept(server_socket, [&](error_code error) {
-            BOOST_ASSERT(!error);
+            BOOST_VERIFY(!error);
 
             server_socket.async_send(asio::buffer(tx_data),
                 [&](error_code error, size_t size) {
@@ -140,12 +140,12 @@ BOOST_AUTO_TEST_CASE(accept_send___connect_receive)
     client_socket.async_connect(
             acceptor.local_endpoint(),
             [&](error_code error) {
-              BOOST_ASSERT(!error);
+              BOOST_VERIFY(!error);
 
               client_socket.async_receive(
                   asio::buffer(rx_data),
                   [&](const error_code& error, size_t size) {
-                    BOOST_ASSERT(!error);
+                    BOOST_VERIFY(!error);
                     BOOST_REQUIRE_EQUAL(size, tx_data.size());
                     BOOST_REQUIRE_EQUAL(to_string(rx_data), to_string(tx_data));
 
@@ -177,13 +177,13 @@ BOOST_AUTO_TEST_CASE(accept_receive_receive___connect_send_send)
     std::vector<char>  rx_data(blank_message.begin(), blank_message.end());
 
     acceptor.async_accept(server_socket, [&](error_code error) {
-            BOOST_ASSERT(!error);
+            BOOST_VERIFY(!error);
 
             server_socket.async_receive(
                 asio::buffer(rx_data),
                 [&](const error_code& error, size_t size) {
-                  BOOST_ASSERT(!error);
-                  BOOST_ASSERT(size == message1_text.size());
+                  BOOST_VERIFY(!error);
+                  BOOST_VERIFY(size == message1_text.size());
                   BOOST_REQUIRE_EQUAL
                       (to_string(rx_data), message1_text);
 
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(accept_receive_receive___connect_send_send)
                   server_socket.async_receive(
                       asio::buffer(rx_data),
                       [&](const error_code& error, size_t size) {
-                          BOOST_ASSERT(!error);
+                          BOOST_VERIFY(!error);
                           BOOST_REQUIRE_EQUAL(size, rx_data.size());
                           BOOST_REQUIRE_EQUAL
                             (to_string(rx_data), message2_text);
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(accept_receive_receive___connect_send_send)
     client_socket.async_connect(
             acceptor.local_endpoint(),
             [&](error_code error) {
-              BOOST_ASSERT(!error);
+              BOOST_VERIFY(!error);
 
               client_socket.async_send(asio::buffer(tx_data),
                   [&](error_code error, size_t size) {
@@ -245,21 +245,21 @@ BOOST_AUTO_TEST_CASE(accept_receive_send___connect_send_receive)
     std::vector<char> server_tx_data(message2_text.begin(), message2_text.end());
 
     acceptor.async_accept(server_socket, [&](error_code error) {
-            BOOST_ASSERT(!error);
+            BOOST_VERIFY(!error);
 
             server_socket.async_receive(
                 asio::buffer(server_rx_data),
                 [&](const error_code& error, size_t size) {
-                  BOOST_ASSERT(!error);
-                  BOOST_ASSERT(size == message1_text.size());
+                  BOOST_VERIFY(!error);
+                  BOOST_VERIFY(size == message1_text.size());
                   BOOST_REQUIRE_EQUAL
                       (to_string(server_rx_data), message1_text);
 
                   server_socket.async_send(
                       asio::buffer(server_tx_data),
                       [&](const error_code& error, size_t size) {
-                          BOOST_ASSERT(!error);
-                          BOOST_ASSERT(size == server_tx_data.size());
+                          BOOST_VERIFY(!error);
+                          BOOST_VERIFY(size == server_tx_data.size());
                       });
                 });
             });
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(accept_receive_send___connect_send_receive)
     client_socket.async_connect(
             acceptor.local_endpoint(),
             [&](error_code error) {
-              BOOST_ASSERT(!error);
+              BOOST_VERIFY(!error);
 
               client_socket.async_send(asio::buffer(client_tx_data),
                   [&](error_code error, size_t size) {
@@ -313,12 +313,13 @@ BOOST_AUTO_TEST_CASE(keepalive_timeout)
     acceptor.async_accept
         ( server_socket
         , [&](error_code error) {
-              BOOST_ASSERT(!error);
+              BOOST_VERIFY(!error);
 
               server_socket.async_receive(
                   asio::null_buffers(),
                   [&](const error_code& error, size_t size) {
-                    BOOST_ASSERT(error);
+                    BOOST_VERIFY(error);
+                    static_cast<void>(size);
                     tested_server = true;
                   });
           });
@@ -326,7 +327,7 @@ BOOST_AUTO_TEST_CASE(keepalive_timeout)
     client_socket.async_connect
         ( acceptor.local_endpoint()
         , [&](error_code error) {
-            BOOST_ASSERT(!error);
+            BOOST_VERIFY(!error);
             tested_client = true;
             client_socket.close();
           });


### PR DESCRIPTION
Rather than all the `static_cast<void>(error);` instances in socket.cpp I'd proposed earlier, I just changed from using `BOOST_ASSERT` to using `BOOST_VERIFY`.  I hope that's OK.
